### PR TITLE
Add missing import logging to tor.py

### DIFF
--- a/gateways/tor.py
+++ b/gateways/tor.py
@@ -2,8 +2,8 @@ import socks
 import json
 import requests
 import time
-
 import config
+import logging
 
 time.sleep(3)
 


### PR DESCRIPTION
Fixes `NameError: name 'logging' is not defined` error when using tor.py
