### PR TITLE
Fix missing import logging

### DIFF
--- a/gateways/tor.py
+++ b/gateways/tor.py
@@ -2,8 +2,8 @@ import socks
 import json
 import requests
 import time
-
 import config
+import logging
 
 time.sleep(3)
 


### PR DESCRIPTION
There was an error when running SatSale via Tor:
```
  File "/home/user/code/SatSale/gateways/tor.py", line 13, in <module>
    logging.info("Using tor proxies {}".format(config.tor_proxy))
NameError: name 'logging' is not defined

```