### PR TITLE
Simple database schema versioning and migration

### DIFF
--- a/satsale.py
+++ b/satsale.py
@@ -50,6 +50,8 @@ logging.info("Initialised Flask with secret key: {}".format(app.config["SECRET_K
 # Create payment database if it does not exist
 if not os.path.exists("database.db"):
     database.create_database()
+# Check and migrate database to current version if needed
+database.migrate_database()
 
 
 # Render index page


### PR DESCRIPTION
For simple database updates, like adding new table, code can just check if table exists and then create if it doesn't. But for #53, more serious database migration would be needed, adding rows to multiple new tables from existing `payments` table.

Was looking around how people do it in Python, Alembic from SQLAlchemy seems like the way people are doing this, but that seems like an overkill for simple project like this. So, decided to roll my own simple (quick'n'dirty) database schema versioning and migration and this is what I came up with.

Taking #36 as example, where just new table is created, instead of `check_address_table_exists()` and `create_address_table()` logic there currently, this could be done with this by adding following code to `migrate_database()`:
```Python
if schema_version < 2:
    _log_migrate_database(1, 2, "Creating new table for generated addresses")
    with sqlite3.connect(name) as conn:
        conn.execute("CREATE TABLE addresses (n INTEGER, address TEXT)")
    _set_database_schema_version(2)
```