### PR TITLE
Fix missing import logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pay/__pycache__/
 SatSale_API_key
 .venv/
 database.db
+.python-version

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+satsale

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-satsale

--- a/gateways/tor.py
+++ b/gateways/tor.py
@@ -2,6 +2,7 @@ import socks
 import json
 import requests
 import time
+import logging
 
 import config
 


### PR DESCRIPTION
Fixes error `NameError: name 'logging' is not defined` when using tor.py