### PR TITLE
gunicorn conf controls ssh processes

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,11 @@
+from gateways import ssh_tunnel
+
+def on_starting(server):
+    server.ssh_processes = ssh_tunnel.open_tunnels()
+
+def on_reload(server):
+    ssh_tunnel.close_tunnels(server.ssh_processes)
+    server.ssh_processes = ssh_tunnel.open_tunnels()
+
+def worker_exit(server, worker):
+    ssh_tunnel.close_tunnels(server.ssh_processes)


### PR DESCRIPTION
Fixes a bug where satsale would open SSH processes in background and not close them.

Unfortunately can't use `finally` with gunicorn, so have to use hooks in `gunicorn.conf.py`. I wish these could be put in the main file and not hidden.  Also might need to shuffle the logging code in there to avoid using `print`

The plus side with the config file is that SatSale performance could probably be greatly improved by some preloading and worker optimization, but not really a priority for me