### PR TITLE
Fix connecting to non-localhost clearnet bitcoind

### DIFF
--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -37,13 +37,13 @@ class btcd:
                 connection_str = "http://{}:{}@{}:{}/wallet/{}".format(
                     username,
                     password,
-                    config.host,
+                    self.config['host'],
                     self.config['rpcport'],
                     self.config['wallet'],
                 )
                 logging.info(
-                    "Attempting to connect to Bitcoin node RPC with user {}.".format(
-                        self.config['username']
+                    "Attempting to connect to Bitcoin node RPC to {}:{} with user {}.".format(
+                        self.config['host'], self.config['rpcport'], self.config['username']
                     )
                 )
             else:

--- a/satsale.py
+++ b/satsale.py
@@ -343,7 +343,7 @@ api.add_resource(complete_payment, "/api/completepayment")
 # Test connections on startup:
 enabled_payment_methods = []
 for method in config.payment_methods:
-    print(method)
+    #print(method)
     if method['name'] == "bitcoind":
         bitcoin_node = bitcoind.btcd(method)
         logging.info("Connection to bitcoin node successful.")


### PR DESCRIPTION
Bug introduced with #49. Also added host:port info to connecting log message and commented out bad debug lefover print (outputs RPC password).