### PR TITLE
Comment out debug print()'s

### DIFF
--- a/config.py
+++ b/config.py
@@ -102,5 +102,5 @@ paynym = get_opt("paynym", None)
 free_mode = get_opt("free_mode", False)
 loglevel = get_opt("loglevel", "DEBUG")
 
-print(config)
-print(tunnel_host)
+#print(config)
+#print(tunnel_host)


### PR DESCRIPTION
`print(config)` is especially bad, as it contains Bitcoin RPC password, not something you want to be in logfile.