### PR TITLE
QA: Add flake8 python linter script and fix found errors

### DIFF
--- a/gateways/lightning_address.py
+++ b/gateways/lightning_address.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restplus import Resource, Api, Namespace, fields
+from flask_restplus import Resource
 import hashlib
 import logging
 
@@ -7,6 +7,7 @@ min_sats = 10 ** 2
 max_sats = 10 ** 6
 
 # Following https://github.com/andrerfneves/lightning-address/blob/master/DIY.md
+
 
 def add_ln_address_decorators(app, api, node):
     description = node.config['lightning_address_comment']

--- a/gateways/paynym.py
+++ b/gateways/paynym.py
@@ -59,12 +59,6 @@ def insert_paynym_html(nym):
     </style>
     """
 
-    paynym_name_html = """
-    <small style="vertical-align:middle"><a href="{}" target="_blank">{}</a></small>
-    """.format(
-        paynym_site + nym, nym
-    )
-
     nym_html = (
         """
     <div class="paynym">

--- a/gateways/ssh_tunnel.py
+++ b/gateways/ssh_tunnel.py
@@ -1,10 +1,8 @@
 import subprocess
-import time
 import os
 import logging
 
 import config
-from node import bitcoind
 
 
 def open_tunnel(host, port):
@@ -19,12 +17,11 @@ def open_tunnel(host, port):
             config.tunnel_host,
             "-p {}".format(config.tunnel_port),
         ]
-        print("Opening tunnel to {}.".format(" ".join(command)))
+        logging.info("Opening tunnel to {}.".format(" ".join(command)))
         return subprocess.Popen(command)
 
-
     except Exception as e:
-        print("FAILED TO OPEN TUNNEL. Exception: {}".format(e))
+        logging.error("FAILED TO OPEN TUNNEL. Exception: {}".format(e))
 
     return None
 
@@ -45,13 +42,12 @@ def clightning_unix_domain_socket_ssh(rpc_file, rpc_store_dir=None):
             "{}".format(config.tunnel_host),
             "-p {}".format(config.tunnel_port),
             ]
-        print("Opening tunnel to {}.".format(" ".join(command)))
+        logging.info("Opening tunnel to {}.".format(" ".join(command)))
         tunnel_proc = subprocess.Popen(command)
         return tunnel_proc
 
-
     except Exception as e:
-        print(
+        logging.error(
             "FAILED TO OPEN UNIX DOMAIN SOCKET OVER SSH. Exception: {}".format(e)
         )
 
@@ -63,12 +59,13 @@ def rm_lightning_rpc_file():
         os.remove("lightning-rpc")
     return
 
+
 def close_tunnels(ssh_processes):
     if ssh_processes is not None:
         for proc in ssh_processes:
             try:
                 proc.kill()
-            except Exception as e:
+            except Exception:
                 continue
 
     if "clightning" in config.payment_methods:

--- a/gateways/tor.py
+++ b/gateways/tor.py
@@ -1,5 +1,3 @@
-import socks
-import json
 import requests
 import time
 import logging

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,11 +1,14 @@
 from gateways import ssh_tunnel
 
+
 def on_starting(server):
     server.ssh_processes = ssh_tunnel.open_tunnels()
+
 
 def on_reload(server):
     ssh_tunnel.close_tunnels(server.ssh_processes)
     server.ssh_processes = ssh_tunnel.open_tunnels()
+
 
 def worker_exit(server, worker):
     ssh_tunnel.close_tunnels(server.ssh_processes)

--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -3,11 +3,10 @@ import logging
 import os
 import qrcode
 import time
-import uuid
 
 import config
-from payments.price_feed import get_btc_value
 from utils import btc_amount_format
+
 
 class btcd:
     def __init__(self, node_config):

--- a/node/clightning.py
+++ b/node/clightning.py
@@ -1,14 +1,7 @@
-import subprocess
-import pathlib
 import time
-import os
-import json
-import uuid
 import qrcode
 import logging
 
-
-from payments.price_feed import get_btc_value
 import config
 
 # if False:  # config.tor_clightningrpc_host is not None:

--- a/node/lnd.py
+++ b/node/lnd.py
@@ -1,16 +1,12 @@
 import subprocess
-import pathlib
 import time
 import os
 import json
 from base64 import b64decode
 from google.protobuf.json_format import MessageToJson
-import uuid
 import qrcode
 import logging
 
-
-from payments.price_feed import get_btc_value
 import config
 
 

--- a/node/xpub.py
+++ b/node/xpub.py
@@ -1,14 +1,9 @@
 import time
-import uuid
 import qrcode
-import json
-import os
 import logging
 import requests
 from bip_utils import Bip84, Bip44Changes, Bip84Coins, Bip44, Bip44Coins
 
-import config
-from payments.price_feed import get_btc_value
 from utils import btc_amount_format
 from payments import database
 

--- a/payments/price_feed.py
+++ b/payments/price_feed.py
@@ -38,15 +38,15 @@ def get_price(currency, currency_provider=config.currency_provider):
             )
 
     else:
-        raise ("Failed to reach {}.".format(price_feed))
+        raise ("Failed to reach {}.".format(provider["price_feed"]))
 
     try:
         price = prices[provider["ticker"]][provider["value_attribute"]]
         return price
 
-    except:
+    except Exception:
         logging.error(
-            "Failed to find currency {} from {}.".format(currency, price_feed)
+            "Failed to find currency {} from {}.".format(currency, provider["price_feed"])
         )
         return None
 

--- a/payments/weakhands.py
+++ b/payments/weakhands.py
@@ -1,9 +1,6 @@
 import requests
 import logging
 
-import config
-
-# import config
 
 quote_url = "https://sideshift.ai/api/v1/quotes"
 swap_url = "https://sideshift.ai/api/v1/orders"

--- a/satsale.py
+++ b/satsale.py
@@ -2,18 +2,13 @@ from flask import (
     Flask,
     render_template,
     request,
-    redirect,
-    Blueprint,
-    make_response,
-    url_for,
+    make_response
 )
-from flask_restplus import Resource, Api, Namespace, fields
+from flask_restplus import Resource, Api, fields
 import time
 import os
 import uuid
-import sqlite3
 from pprint import pprint
-import json
 import qrcode
 import logging
 
@@ -26,7 +21,6 @@ logging.basicConfig(
     level=getattr(logging, config.loglevel),
 )
 
-from gateways import ssh_tunnel
 from gateways import paynym
 from payments import database, weakhands
 from payments.price_feed import get_btc_value
@@ -136,7 +130,6 @@ class create_payment(Resource):
         """Initiate a new payment with an `amount` in `config.base_currecy`."""
         base_amount = request.args.get("amount")
         currency = config.base_currency
-        label = ""  # request.args.get('label')
         payment_method = request.args.get("method")
         if payment_method is None:
             payment_method = enabled_payment_methods[0]
@@ -260,7 +253,7 @@ class complete_payment(Resource):
             )
 
         # Call webhook to confirm payment with merchant
-        if (invoice["webhook"] != None) and (invoice["webhook"] != ""):
+        if (invoice["webhook"] is not None) and (invoice["webhook"] != ""):
             logging.info("Calling webhook {}".format(invoice["webhook"]))
             response = woo_webhook.hook(app.config["SECRET_KEY"], invoice, order_id)
 
@@ -374,7 +367,7 @@ for method in config.payment_methods:
 if config.node_info is not None:
     @app.route("/node/")
     def node():
-        if config.node_info == True:
+        if config.node_info is True:
             uri = lightning_node.get_uri()
         else:
             uri = config.node_info
@@ -385,7 +378,7 @@ if config.node_info is not None:
             render_template("node.html", params={"uri": uri}), 200, headers
         )
 
-# Add lightning address 
+# Add lightning address
 try:
     if lightning_node.config['lightning_address'] is not None:
         from gateways import lightning_address

--- a/scripts/generate_payment_report.py
+++ b/scripts/generate_payment_report.py
@@ -8,9 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 import config
 from payments import database
-from node import bitcoind
-from node import lnd
-from node import clightning
+from node import bitcoind, clightning, lnd, xpub
 
 
 def valid_date(s):
@@ -26,9 +24,9 @@ def main():
         description="Generate CSV report about received payments.")
     parser.add_argument("report_file")
     parser.add_argument("--date-from", required=False, dest="date_from",
-        help="from date (YYYY-MM-DD)", type=valid_date)
+                        help="from date (YYYY-MM-DD)", type=valid_date)
     parser.add_argument("--date-to", required=False, dest="date_to",
-        help="to date (YYYY-MM-DD)", type=valid_date)
+                        help="to date (YYYY-MM-DD)", type=valid_date)
 
     try:
         args = parser.parse_args()

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Based on https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/test/lint/lint-python.sh
+# Based on Bitcoin Core's test/lint/lint-python.sh
+
+# E265 block comment should start with '# '
+# E402 module level import not at top of file
+# E501 line too long
+IGNORE_ERRORS="E265,E402,E501"
+
+EXCLUDE_PATTERNS="docs/*"
+
+if ! command -v flake8 > /dev/null; then
+    echo "Skipping Python linting since flake8 is not installed."
+    exit 0
+elif flake8 --version | grep -q "Python 2"; then
+    echo "Skipping Python linting since flake8 is running under Python 2. Install the Python 3 version of flake8."
+    exit 0
+fi
+
+if [[ $# == 0 ]]; then
+    flake8 $(git ls-files "*.py") \
+        --extend-ignore "${IGNORE_ERRORS}" \
+        --extend-exclude "${EXCLUDE_PATTERNS}"
+else
+    flake8 "$@" \
+        --extend-ignore "${IGNORE_ERRORS}"
+fi

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,3 @@
 
 def btc_amount_format(btc_amount):
     return "%.8f" % float(btc_amount)
-


### PR DESCRIPTION
Added three exceptions on top of flake8 defaults, which were either too much or didn't make sense for me:
* E265 block comment should start with '# ';
* E402 module level import not at top of file;
* E501 line too long.

Also added `docs/*` to ignored files list, because of errors in config examples [that need to be changed anyway](https://github.com/SatSale/SatSale/issues/70).

List of errors fixed:
```
gateways/lightning_address.py:2:1: F401 'flask_restplus.Api' imported but unused
gateways/lightning_address.py:2:1: F401 'flask_restplus.Namespace' imported but unused
gateways/lightning_address.py:2:1: F401 'flask_restplus.fields' imported but unused
gateways/lightning_address.py:11:1: E302 expected 2 blank lines, found 1
gateways/paynym.py:62:5: F841 local variable 'paynym_name_html' is assigned to but never used
gateways/ssh_tunnel.py:2:1: F401 'time' imported but unused
gateways/ssh_tunnel.py:4:1: F401 'logging' imported but unused
gateways/ssh_tunnel.py:7:1: F401 'node.bitcoind' imported but unused
gateways/ssh_tunnel.py:26:5: E303 too many blank lines (2)
gateways/ssh_tunnel.py:53:5: E303 too many blank lines (2)
gateways/ssh_tunnel.py:66:1: E302 expected 2 blank lines, found 1
gateways/ssh_tunnel.py:71:13: F841 local variable 'e' is assigned to but never used
gateways/tor.py:1:1: F401 'socks' imported but unused
gateways/tor.py:2:1: F401 'json' imported but unused
gunicorn.conf.py:3:1: E302 expected 2 blank lines, found 1
gunicorn.conf.py:6:1: E302 expected 2 blank lines, found 1
gunicorn.conf.py:10:1: E302 expected 2 blank lines, found 1
node/bitcoind.py:6:1: F401 'uuid' imported but unused
node/bitcoind.py:9:1: F401 'payments.price_feed.get_btc_value' imported but unused
node/bitcoind.py:12:1: E302 expected 2 blank lines, found 1
node/bitcoind.py:100:25: F811 redefinition of unused 'uuid' from line 6
node/bitcoind.py:109:29: F811 redefinition of unused 'uuid' from line 6
node/clightning.py:1:1: F401 'subprocess' imported but unused
node/clightning.py:2:1: F401 'pathlib' imported but unused
node/clightning.py:4:1: F401 'os' imported but unused
node/clightning.py:5:1: F401 'json' imported but unused
node/clightning.py:6:1: F401 'uuid' imported but unused
node/clightning.py:11:1: F401 'payments.price_feed.get_btc_value' imported but unused
node/clightning.py:69:25: F811 redefinition of unused 'uuid' from line 6
node/clightning.py:97:29: F811 redefinition of unused 'uuid' from line 6
node/lnd.py:2:1: F401 'pathlib' imported but unused
node/lnd.py:8:1: F401 'uuid' imported but unused
node/lnd.py:13:1: F401 'payments.price_feed.get_btc_value' imported but unused
node/lnd.py:76:25: F811 redefinition of unused 'uuid' from line 8
node/xpub.py:2:1: F401 'uuid' imported but unused
node/xpub.py:4:1: F401 'json' imported but unused
node/xpub.py:5:1: F401 'os' imported but unused
node/xpub.py:10:1: F401 'config' imported but unused
node/xpub.py:11:1: F401 'payments.price_feed.get_btc_value' imported but unused
node/xpub.py:38:25: F811 redefinition of unused 'uuid' from line 2
payments/price_feed.py:41:45: F821 undefined name 'price_feed'
payments/price_feed.py:47:5: E722 do not use bare 'except'
payments/price_feed.py:49:68: F821 undefined name 'price_feed'
payments/weakhands.py:4:1: F401 'config' imported but unused
satsale.py:1:1: F401 'flask.redirect' imported but unused
satsale.py:1:1: F401 'flask.Blueprint' imported but unused
satsale.py:1:1: F401 'flask.url_for' imported but unused
satsale.py:10:1: F401 'flask_restplus.Namespace' imported but unused
satsale.py:14:1: F401 'sqlite3' imported but unused
satsale.py:16:1: F401 'json' imported but unused
satsale.py:29:1: F401 'gateways.ssh_tunnel' imported but unused
satsale.py:139:9: F841 local variable 'label' is assigned to but never used
satsale.py:263:32: E711 comparison to None should be 'if cond is not None:'
satsale.py:377:29: E712 comparison to True should be 'if cond is True:' or 'if cond:'
satsale.py:388:24: W291 trailing whitespace
scripts/generate_payment_report.py:29:9: E128 continuation line under-indented for visual indent
scripts/generate_payment_report.py:31:9: E128 continuation line under-indented for visual indent
scripts/generate_payment_report.py:54:29: F821 undefined name 'xpub'
utils.py:4:1: W391 blank line at end of file
```

We could now think about adding CI using GitHub Actions and run `test/lint/lint-python.sh` automatically.