### PR TITLE
Set expiration time for LN invoices

### DIFF
--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -121,7 +121,7 @@ class btcd:
 
         return conf_paid, unconf_paid
 
-    def get_address(self, amount, label):
+    def get_address(self, amount, label, expiry):
         for i in range(config.connection_attempts):
             try:
                 if not self.tor:

--- a/node/clightning.py
+++ b/node/clightning.py
@@ -74,16 +74,16 @@ class clightning:
         return info["id"] + "@" + address["address"] + ":" + str(address["port"])
 
     # Create lightning invoice
-    def create_clightning_invoice(self, btc_amount, label):
+    def create_clightning_invoice(self, btc_amount, label, expiry):
         # Multiplying by 10^8 to convert to satoshi units
         msats_amount = int(float(btc_amount) * 10 ** (3 + 8))
         lnd_invoice = self.clightning.invoice(
-            msats_amount, label, "SatSale-{}".format(label)
+            msats_amount, label, "SatSale-{}".format(label), expiry
         )
         return lnd_invoice["bolt11"], lnd_invoice["payment_hash"]
 
-    def get_address(self, amount, label):
-        address, r_hash = self.create_clightning_invoice(amount, label)
+    def get_address(self, amount, label, expiry):
+        address, r_hash = self.create_clightning_invoice(amount, label, expiry)
         return address, r_hash
 
     # Check whether the payment has been paid

--- a/node/lnd.py
+++ b/node/lnd.py
@@ -134,8 +134,9 @@ class lnd:
 
         return lnd_invoice["paymentRequest"], lnd_invoice["rHash"]
 
-    def get_address(self, amount, label):
-        address, r_hash = self.create_lnd_invoice(amount, memo=label)
+    def get_address(self, amount, label, expiry):
+        address, r_hash = self.create_lnd_invoice(amount,
+            memo=label, expiry=expiry)
         return address, r_hash
 
     def pay_invoice(self, invoice):

--- a/node/xpub.py
+++ b/node/xpub.py
@@ -80,7 +80,7 @@ class xpub:
         address = child_key.PublicKey().ToAddress()
         return address
 
-    def get_address(self, amount, label):
+    def get_address(self, amount, label, expiry):
         while True:
             n = self.get_next_address_index(self.config["xpub"])
             address = self.get_address_at_index(n)

--- a/satsale.py
+++ b/satsale.py
@@ -171,7 +171,7 @@ class create_payment(Resource):
         # Get an address / invoice, and create a QR code
         try:
             invoice["address"], invoice["rhash"] = node.get_address(
-                invoice["btc_value"], invoice["uuid"]
+                invoice["btc_value"], invoice["uuid"], config.payment_timeout
             )
         except Exception as e:
             logging.error("Failed to fetch address: {}".format(e))


### PR DESCRIPTION
Use `payment_timeout` as expiry for LN invoices.

Note - have tested only with CLN and onchain (bitcoind), not LND. If somebody has already ready setup for that, would appreciate feedback. Otherwise will need to set up it especially for this test.

Fixes #78.