### PR TITLE
Add configurable underpay amount for invoices to be considered paid

### DIFF
--- a/config.py
+++ b/config.py
@@ -98,10 +98,14 @@ redirect = get_opt("redirect", "https://github.com/nickfarrow/satsale")
 base_currency = get_opt("base_currency", "USD")
 currency_provider = get_opt("currency_provider", "COINGECKO")
 bitcoin_rate_multiplier = get_opt("bitcoin_rate_multiplier", 1.00)
+allowed_underpay_amount = get_opt("allowed_underpay_amount", 0.00000001)
 liquid_address = get_opt("liquid_address", None)
 paynym = get_opt("paynym", None)
 free_mode = get_opt("free_mode", False)
 loglevel = get_opt("loglevel", "DEBUG")
+
+if allowed_underpay_amount < 0:
+    raise Exception("allowed_underpay_amount cannot be negative")
 
 #print(config)
 #print(tunnel_host)

--- a/config.toml
+++ b/config.toml
@@ -98,6 +98,11 @@ currency_provider = "COINGECKO"   # Supported: COINDESK | COINGECKO
 # Values above 1.00 gives discount, values below add extra comission.
 bitcoin_rate_multiplier = 1.00
 
+# BTC amount allowed to be underpaid to consider invoice paid.
+# It's recommended to keep it at least 0.00000001 BTC currently,
+# due to https://github.com/SatSale/SatSale/issues/77 bug.
+allowed_underpay_amount = 0.00000001
+
 # Weak Hands Mode - Automatically swap LN-BTC -> L-USDT using sideshift.ai
 # https://blockstream.com/liquid/
 # Change lnd_macaroon='admin.macaroon', as you will also need to be able to spend with your lnd certificates.

--- a/satsale.py
+++ b/satsale.py
@@ -300,7 +300,7 @@ def check_payment_status(uuid):
         dbg_free_mode_cond = config.free_mode and (time.time() - invoice["time"] > 5)
 
         # If payment is paid
-        if (conf_paid >= float(invoice["btc_value"])) or dbg_free_mode_cond:
+        if (conf_paid >= float(invoice["btc_value"]) - config.allowed_underpay_amount) or dbg_free_mode_cond:
             status.update(
                 {
                     "payment_complete": 1,


### PR DESCRIPTION
Some merchants might want to allow underpay of small amount for invoices, as there are at least two cases where inexperienced users can pay less for onchain payments: 1) user pays required amount minus tx fee, 2) for some older wallets if you configure fiat as your display currency, wallet will may change BTC amount while user is reviewing payment if BTC/fiat exchange rate changes. [BTCPay Server has similar config, but in percentage](https://docs.btcpayserver.org/FAQ/Stores/#consider-the-invoice-paid-even-if-the-paid-amount-is-less-than-expected). I think fixed BTC amount makes more sense.

As a side effect this is also simple temporary workaround for #77 bug, that's why I choose 1 satoshi default value.