### PR TITLE
Multiple currencies v3

### DIFF
--- a/config.py
+++ b/config.py
@@ -79,9 +79,22 @@ for method_name in config["payment_methods"]:
             raise KeyError("Mising {}: config {}".format(method_name, "xpub"))
 
     else:
-        Exception("Unknown payment method: {}".format(method_name))
+        raise Exception("Unknown payment method: {}".format(method_name))
 
     payment_methods.append(method_config)
+
+supported_currencies = get_opt("supported_currencies", ["USD"])
+if "BTC" in supported_currencies:
+    supported_currencies.append("sats")
+
+base_currency = get_opt("base_currency", "USD")
+if base_currency not in supported_currencies:
+    raise Exception("base_currency must be one of supported_currencies")
+
+currency_provider = get_opt("currency_provider", "COINGECKO")
+if currency_provider not in ["COINDESK","COINGECKO"]:
+    raise Exception("Unsupported currency price feed provider: {}".format(
+        currency_provider))
 
 host = get_opt("host", "127.0.0.1")
 api_key_path = get_opt("api_key_path", "SatSale_API_key")
@@ -95,8 +108,6 @@ payment_timeout = get_opt("payment_timeout", 60 * 60)
 required_confirmations = get_opt("required_confirmations", 2)
 connection_attempts = get_opt("connection_attempts", 3)
 redirect = get_opt("redirect", "https://github.com/nickfarrow/satsale")
-base_currency = get_opt("base_currency", "USD")
-currency_provider = get_opt("currency_provider", "COINGECKO")
 bitcoin_rate_multiplier = get_opt("bitcoin_rate_multiplier", 1.00)
 allowed_underpay_amount = get_opt("allowed_underpay_amount", 0.00000001)
 liquid_address = get_opt("liquid_address", None)

--- a/config.toml
+++ b/config.toml
@@ -91,8 +91,9 @@ loglevel = "DEBUG"
 redirect = "https://github.com/nickfarrow/satsale"
 
 # Currency and exchange rate provider
-base_currency = "USD"
-currency_provider = "COINGECKO"   # Supported: COINDESK | COINGECKO
+supported_currencies = ["BTC", "USD"]   # Currencies to display on donation dropdown
+base_currency = "USD"                   # Selection default for that dropdown
+currency_provider = "COINGECKO"         # Supported: COINDESK | COINGECKO
 
 # Multiplier added on top of BTC / fiat exchange rate. Allows to give discount or add extra commission.
 # Values above 1.00 gives discount, values below add extra comission.

--- a/payments/database.py
+++ b/payments/database.py
@@ -49,7 +49,13 @@ def migrate_database(name="database.db"):
             conn.execute("CREATE TABLE addresses (n INTEGER, address TEXT, xpub TEXT)")
         _set_database_schema_version(2)
 
-    #if schema_version < 2:
+    if schema_version < 3:
+        _log_migrate_database(2, 3, "Adding fiat currency column to payments table")
+        with sqlite3.connect(name) as conn:
+            conn.execute("ALTER TABLE payments ADD fiat_currency TEXT")
+        _set_database_schema_version(3)
+
+    #if schema_version < 4:
     #   do next migration
 
     new_version = _get_database_schema_version(name)
@@ -65,9 +71,10 @@ def write_to_database(invoice, name="database.db"):
     with sqlite3.connect(name) as conn:
         cur = conn.cursor()
         cur.execute(
-            "INSERT INTO payments (uuid,fiat_value,btc_value,method,address,time,webhook,rhash) VALUES (?,?,?,?,?,?,?,?)",
+            "INSERT INTO payments (uuid,fiat_currency,fiat_value,btc_value,method,address,time,webhook,rhash) VALUES (?,?,?,?,?,?,?,?,?)",
             (
                 invoice["uuid"],
+                invoice["fiat_currency"],
                 invoice["fiat_value"],
                 invoice["btc_value"],
                 invoice["method"],

--- a/payments/price_feed.py
+++ b/payments/price_feed.py
@@ -56,6 +56,11 @@ def get_price(currency, currency_provider=config.currency_provider, bitcoin_rate
 
 
 def get_btc_value(base_amount, currency):
+    if currency == "BTC":
+        return float(base_amount)
+    elif currency == "sats":
+        return float(base_amount) / 10**8
+
     price = get_price(currency)
 
     if price is not None:

--- a/static/satsale.js
+++ b/static/satsale.js
@@ -2,7 +2,7 @@
 function payment(payment_data) {
     $('document').ready(function(){
         var payment_uuid;
-        var invoiceData = {amount: payment_data.amount, method: payment_data.method};
+        var invoiceData = {amount: payment_data.amount, currency: payment_data.currency, method: payment_data.method};
 
         // If a webhook URL is provided (woocommerce)
         if (payment_data.w_url) {

--- a/static/style.css
+++ b/static/style.css
@@ -101,11 +101,12 @@ h1 {
     transform: scale(3);
 }
 
-#amountenter {
+.donate_input {
     background-color: black;
     color: white;
     font-size: 16px;
     border-radius:5px;
+    display: inline;
 }
 
 #qrImage {

--- a/templates/donate.html
+++ b/templates/donate.html
@@ -47,7 +47,12 @@
             <form id="pay" action='/pay'>
                 <div style="display:block;text-align: center;">
                     <h2 style="margin:0;">Amount:
-                    <input id="amountenter" style="display:inline" size="4" type="float" name="amount" id="amount" placeholder="{{ params.currency }}" required>
+                    <input class="donate_input" size="4" type="float" name="amount" placeholder="0" required>
+                    <select class="donate_input" name="currency" required>
+                        {% for currency_option in params.supported_currencies %}
+                        <option value="{{currency_option}}"{% if currency_option == params.base_currency %} selected{% endif %}>{{currency_option}}</option>
+                        {% endfor %}
+                    </select>
                     </h2>
                     <br>
                     <input class="button button1" style="width:40%" type="submit" value="Donate">


### PR DESCRIPTION
This is based on #76, with few changes and bugfixes. Tested myself various scenarios, it works.

1) You can specify `BTC` in addition to fiat currencies in a supported currency list. In that case also `sats` will be added as an option automatically.
2) `base_currency` config option is kept, it will specify default selection for a list of supported currencies. Also made `supported_currencies` default to just `USD`, so that for people who had `base_currency = USD` default previously, this will work as before, without requirement to even add `supported_currencies` to config.
3) Some config sanity checks.
4) Removed rewrite of `payments/price_feed.py` with `PriceFeed` class. It's likely good idea, just out of scope for this PR. Separate refactor PR can be opened for that, but better when author will have time to test it himself (hint - SatSale works with signet too, which is kinda lightweight and syncs fast, you can just install bitcoin-qt on your development computer).
5) Some HTML / CSS changes.

Note - when user select `BTC` or `sats` in donation page, this value will be in db field `fiat_currency`. In this regard maybe we should rename it to `specified_currency` or something, but maybe it's not a big deal for now, in that case we should also rename `fiat_amount` column.

Co-authored-by: @eddiepease

Fixes #18.