### PR TITLE
Disallow invoices below `allowed_underpay_amount`

### DIFF
--- a/satsale.py
+++ b/satsale.py
@@ -162,6 +162,16 @@ class create_payment(Resource):
                 )
             )
             return {"message": "Amount below dust limit."}, 406
+        if btc_value <= config.allowed_underpay_amount:
+            logging.warning(
+                "Requested payment for {} {} below allowed underpay amount ({} < {})".format(
+                    base_amount,
+                    currency,
+                    btc_amount_format(btc_value),
+                    btc_amount_format(config.allowed_underpay_amount),
+                )
+            )
+            return {"message": "Amount below dust limit."}, 406
 
         invoice = {
             "uuid": str(uuid.uuid4().hex),


### PR DESCRIPTION
Such invoices are otherwise autoconfirmed, without user making a payment at all. Fixes #92.

End user will have the same "Amount below dust limit" message, as I don't think they should know details about configuration. But what came into my mind - should we maybe also output this amount, which would be allowed_underpay_amount for LN, max(allowed_underpay_amount,onchain_dust_limit) for onchain?

Also, likely these log messages should not be warnings, but info, as it's user generated action, not something wrong on server side.