### PR TITLE
Migrate from flask_restplus to flask_restx

### DIFF
--- a/gateways/lightning_address.py
+++ b/gateways/lightning_address.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restplus import Resource
+from flask_restx import Resource
 import hashlib
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests==2.26.0
 gunicorn==20.0.4
 Pillow==9.0.0
 protobuf==3.19.1
-flask_restplus==0.13.0
+flask_restx==0.5.1
 Werkzeug==0.16.1
 PySocks==1.7.1
 toml==0.10.2

--- a/satsale.py
+++ b/satsale.py
@@ -4,7 +4,7 @@ from flask import (
     request,
     make_response
 )
-from flask_restplus import Resource, Api, fields
+from flask_restx import Resource, Api, fields
 import time
 import os
 import uuid


### PR DESCRIPTION
Flask-RESTPlus is unmaintained, new developments are happening on a forked Flask-RestX. See https://github.com/noirbizarre/flask-restplus/issues/770. This is required for Python 3.10 support (solves error I had in #91, but that's not the only error I got when trying SatSale with Python 3.10).