### PR TITLE
Basic test framework (pytest)

### DIFF
--- a/node/xpub.py
+++ b/node/xpub.py
@@ -1,7 +1,8 @@
-import time
-import qrcode
 import logging
+import qrcode
 import requests
+import sys
+import time
 from bip_utils import Bip84, Bip44Changes, Bip84Coins, Bip44, Bip44Coins
 
 from utils import btc_amount_format
@@ -15,7 +16,8 @@ class xpub:
         self.api = "https://mempool.space/api"
 
         next_n = self.get_next_address_index(self.config["xpub"])
-        if next_n == 0:
+        # Warning will be printed for production runs, but not when running tests.
+        if next_n == 0 and "pytest" not in sys.modules:
             logging.info(
                 "Deriving addresses for first time from xpub: {}".format(
                     self.config["xpub"]
@@ -89,25 +91,3 @@ class xpub:
             if conf_paid == 0 and unconf_paid == 0:
                 break
         return address, None
-
-
-def test():
-    # Account 0, root = m/84'/0'/0'
-    test_zpub = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
-    pseudonode = xpub({"xpub": test_zpub, "bip": "BIP84"})
-    assert (
-        pseudonode.get_address_at_index(0)
-        == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
-    )
-    assert (
-        pseudonode.get_address_at_index(1)
-        == "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g"
-    )
-    print("BIP84 test succeded")
-
-    test_xpub = "xpub6C5uh2bEhmF8ck3LSnNsj261dt24wrJHMcsXcV25MjrYNo3ZiduE3pS2Xs7nKKTR6kGPDa8jemxCQPw6zX2LMEA6VG2sypt2LUJRHb8G63i"
-    pseudonode2 = xpub({"xpub": test_xpub, "bip": "BIP44"})
-    assert pseudonode2.get_address_at_index(0) == "1LLNwhAMsS3J9tZR2T4fFg2ibuZyRSxFZg"
-    assert pseudonode2.get_address_at_index(1) == "1EaEuwMRVKdWBoKeJZzJ8abUzVbWNhGhtC"
-    print("BIP44 test succeded")
-    return

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")/.."
+pytest test/test_*.py

--- a/test/test_xpub.py
+++ b/test/test_xpub.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from node.xpub import *
+
+
+def test_xpub():
+    # Account 0, root = m/84'/0'/0'
+    test_zpub = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
+    pseudonode = xpub({"xpub": test_zpub, "bip": "BIP84"})
+    assert (
+        pseudonode.get_address_at_index(0)
+        == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+    )
+    assert (
+        pseudonode.get_address_at_index(1)
+        == "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g"
+    )
+
+    test_xpub = "xpub6C5uh2bEhmF8ck3LSnNsj261dt24wrJHMcsXcV25MjrYNo3ZiduE3pS2Xs7nKKTR6kGPDa8jemxCQPw6zX2LMEA6VG2sypt2LUJRHb8G63i"
+    pseudonode2 = xpub({"xpub": test_xpub, "bip": "BIP44"})
+    assert pseudonode2.get_address_at_index(0) == "1LLNwhAMsS3J9tZR2T4fFg2ibuZyRSxFZg"
+    assert pseudonode2.get_address_at_index(1) == "1EaEuwMRVKdWBoKeJZzJ8abUzVbWNhGhtC"


### PR DESCRIPTION
Very basic for now. Moved existing `test()` function from `node/xpub.py` to `test/test_xpub.py` and added script to run all tests `test/run_tests.sh`. New tests can be added by adding new `test/test_*.py` files. If this looks ok (nobody has better ideas how to organize tests), next steps would be to add test coverage for the rest of functionality and maybe integrate with GitHub CI (which could run both `test/test_all.sh` and `test/lint/lint-python.sh`).