### PR TITLE
Refactor BIP21 (onchain QR code) encoding and add tests

### DIFF
--- a/node/bip21.py
+++ b/node/bip21.py
@@ -1,0 +1,25 @@
+# https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+# bitcoin:<address>[?amount=<amount>][?label=<label>][?message=<message>]
+
+from typing import Union
+from urllib.parse import quote, urlencode
+import re
+
+
+def _is_bip21_amount_str(amount: str) -> bool:
+    return re.compile(r"^[0-9]{1,8}(\.[0-9]{1,8})?$").match(
+        amount) is not None
+
+
+def _validate_bip21_amount(amount: Union[float, int, str]) -> None:
+    if not _is_bip21_amount_str(str(amount)):
+        raise ValueError("Invalid BTC amount " + str(amount))
+
+
+def encode_bip21_uri(address: str, params: Union[dict, list]) -> str:
+    uri = "bitcoin:{}".format(address)
+    if len(params) > 0:
+        if "amount" in params:
+            _validate_bip21_amount(params["amount"])
+        uri += "?" + urlencode(params, quote_via=quote)
+    return uri

--- a/node/bitcoind.py
+++ b/node/bitcoind.py
@@ -5,6 +5,7 @@ import qrcode
 import time
 
 import config
+from node.bip21 import encode_bip21_uri
 from utils import btc_amount_format
 
 
@@ -97,10 +98,10 @@ class btcd:
         return json.loads(response.text)
 
     def create_qr(self, uuid, address, value):
-        qr_str = "bitcoin:{}?amount={}&label={}".format(
-            address, btc_amount_format(value), uuid
-        )
-
+        qr_str = encode_bip21_uri(address, {
+            "amount": btc_amount_format(value),
+            "label": uuid
+        })
         img = qrcode.make(qr_str)
         img.save("static/qr_codes/{}.png".format(uuid))
         return

--- a/node/xpub.py
+++ b/node/xpub.py
@@ -5,6 +5,7 @@ import sys
 import time
 from bip_utils import Bip84, Bip44Changes, Bip84Coins, Bip44, Bip44Coins
 
+from node.bip21 import encode_bip21_uri
 from utils import btc_amount_format
 from payments import database
 
@@ -34,10 +35,10 @@ class xpub:
             logging.info("Next address shown to users is #{}".format(next_n))
 
     def create_qr(self, uuid, address, value):
-        qr_str = "bitcoin:{}?amount={}&label={}".format(
-            address, btc_amount_format(value), uuid
-        )
-
+        qr_str = encode_bip21_uri(address, {
+            "amount": btc_amount_format(value),
+            "label": uuid
+        })
         img = qrcode.make(qr_str)
         img.save("static/qr_codes/{}.png".format(uuid))
         return

--- a/test/test_bip21.py
+++ b/test/test_bip21.py
@@ -1,0 +1,91 @@
+import os
+import pytest
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from node.bip21 import encode_bip21_uri
+
+
+def test_bip21_encode() -> None:
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {}) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"
+    )
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "label": "Luke-Jr"
+        }) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr"
+    )
+    # Both dictionary and list of tuples should work
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("label", "Luke-Jr")
+        ]) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr"
+    )
+    # Use list of tuples version for multiple parameter tests, as dicts don't
+    # have guaranteed ordering.
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", 20.3),
+            ("label", "Luke-Jr")
+        ]) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr"
+    )
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", 50),
+            ("label", "Luke-Jr"),
+            ("message", "Donation for project xyz")
+        ]) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz"
+    )
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("req-somethingyoudontunderstand", 50),
+            ("req-somethingelseyoudontget", 999)
+        ]) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999"
+    )
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("somethingyoudontunderstand", 50),
+            ("somethingelseyoudontget", 999)
+        ]) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?somethingyoudontunderstand=50&somethingelseyoudontget=999"
+    )
+    # Invalid amounts must raise ValueError
+    with pytest.raises(ValueError):
+        # test dicts
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": ""
+        })
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "XYZ"
+        })
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "100'000"
+        })
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "100,000"
+        })
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "100000000"
+        })
+        # test list of tuples
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", "")
+        ])
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", "XYZ")
+        ])
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", "100'000")
+        ])
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", "100,000")
+        ])
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", [
+            ("amount", "100000000")
+        ])


### PR DESCRIPTION
Don't duplicate URI constructing code in `node.bitcoind` and `node.xpub`, move that to `node.bip21`. Code is based on the old code I wrote for JoinMarket (but we are only interested in encoding, not decoding). Test vectors are from BIP21 doc.