### PR TITLE
Fix flake8 linter errors

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,7 +92,7 @@ if base_currency not in supported_currencies:
     raise Exception("base_currency must be one of supported_currencies")
 
 currency_provider = get_opt("currency_provider", "COINGECKO")
-if currency_provider not in ["COINDESK","COINGECKO"]:
+if currency_provider not in ["COINDESK", "COINGECKO"]:
     raise Exception("Unsupported currency price feed provider: {}".format(
         currency_provider))
 

--- a/node/lnd.py
+++ b/node/lnd.py
@@ -135,8 +135,8 @@ class lnd:
         return lnd_invoice["paymentRequest"], lnd_invoice["rHash"]
 
     def get_address(self, amount, label, expiry):
-        address, r_hash = self.create_lnd_invoice(amount,
-            memo=label, expiry=expiry)
+        address, r_hash = self.create_lnd_invoice(
+            amount, memo=label, expiry=expiry)
         return address, r_hash
 
     def pay_invoice(self, invoice):

--- a/test/test_xpub.py
+++ b/test/test_xpub.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from node.xpub import *
+from node.xpub import xpub
 
 
 def test_xpub():


### PR DESCRIPTION
Fixes these:
```
$ ./test/lint/lint-python.sh 
config.py:95:40: E231 missing whitespace after ','
node/lnd.py:139:13: E128 continuation line under-indented for visual indent
test/test_xpub.py:5:1: F403 'from node.xpub import *' used; unable to detect undefined names
test/test_xpub.py:11:18: F405 'xpub' may be undefined, or defined from star imports: node.xpub
test/test_xpub.py:22:19: F405 'xpub' may be undefined, or defined from star imports: node.xpub
```