### PR TITLE
Fix flake8 errors

### DIFF
--- a/payments/price_feed.py
+++ b/payments/price_feed.py
@@ -43,7 +43,7 @@ class PriceFeed(ABC):
             rate = self._get_rate(base_currency)
             if bitcoin_rate_multiplier != 1.00:
                 logging.debug(
-                    "Adjusting BTC/{} exchange rate from {} to {} " +
+                    "Adjusting BTC/{} exchange rate from {} to {} "
                     "because of rate multiplier {}.".format(
                         base_currency, rate, rate * bitcoin_rate_multiplier,
                         bitcoin_rate_multiplier))

--- a/test/test_price_feed.py
+++ b/test/test_price_feed.py
@@ -44,8 +44,8 @@ def test_invalid_base_currency(price_feed: dict) -> None:
     ])
 def test_btc_btc_price(price_feed: dict) -> None:
     provider = price_feed["class"](price_feed_url=None)
-    assert(provider.get_btc_value(1, "BTC") == 1)
-    assert(provider.get_btc_value(1000000, "sats") == 0.01)
+    assert (provider.get_btc_value(1, "BTC") == 1)
+    assert (provider.get_btc_value(1000000, "sats") == 0.01)
 
 
 @pytest.mark.parametrize(
@@ -74,7 +74,7 @@ def test_fiat_btc_price(price_feed: dict) -> None:
     provider = price_feed["class"](price_feed_url=None)
     provider.set_price_data(read_price_feed_data(price_feed["data_file"]))
     for conv in price_feed["conversions"]:
-        assert(
+        assert (
             provider.get_btc_value(conv["base_value"], conv["base_currency"]) ==
             conv["btc_value"]
         )


### PR DESCRIPTION
```
payments/price_feed.py:47:21: F523 '...'.format(...) has unused arguments at position(s): 1, 2, 3
test/test_price_feed.py:47:11: E275 missing whitespace after keyword
test/test_price_feed.py:48:11: E275 missing whitespace after keyword
test/test_price_feed.py:77:15: E275 missing whitespace after keyword
```

Had older version of flake8 installed on my computer, that's why didn't notice before. GitHub Actions are already paying off. :)