### PR TITLE
Refactor bitcoind code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,8 @@ payment_methods = ["bitcoind"]
 # wallet (empty "" if your bitcoind node has a single wallet, OR wallet name/path as shown in `bitcoin-cli listwallets`)
 [bitcoind]
 host = "127.0.0.1"
+# Use this instead of host to connect over Tor
+#tor_bitcoinrpc_host = ""
 username = "bitcoinrpc"
 password = ""
 rpcport = "8332"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python_bitcoinrpc==1.0
 qrcode==7.3
 Flask==1.1.4
 MarkupSafe==2.0.1

--- a/satsale.py
+++ b/satsale.py
@@ -187,6 +187,10 @@ class create_payment(Resource):
             logging.error("Failed to fetch address: {}".format(e))
             return {"message": "Error fetching address. Check config.."}, 522
 
+        if not invoice["address"]:
+            logging.error("Failed to fetch address")
+            return {"message": "Error fetching address. Check config.."}, 522
+
         node.create_qr(invoice["uuid"], invoice["address"], invoice["btc_value"])
 
         # Save invoice to database


### PR DESCRIPTION
* Use same logic to call Bitcoin RPC via Tor and clearnet
* Fix Bitcoin Core multi-wallet setup for Tor
* Get rid of python_bitcoinrpc dependency

Makes code simpler and removes one depenency. We can simply use requests, which are already used by node/xpub, instead of python_bitcoinrpc. Also added type hints.

Resolves #85.