### PR TITLE
Add Blue Wallet Lightning Network backend support (LNDHub)

### DIFF
--- a/config.py
+++ b/config.py
@@ -62,6 +62,14 @@ for method_name in config["payment_methods"]:
         check_set_node_conf("lightning_address", None, method_config)
         check_set_node_conf("lightning_address_comment", None, method_config)
 
+    elif method_name == "lndhub":
+        method_config["name"] = "lndhub"
+        check_set_node_conf("bw_login", None, method_config)
+        check_set_node_conf("bw_password", None, method_config)
+        check_set_node_conf("backend_url", "https://lndhub.herokuapp.com", method_config)
+        check_set_node_conf("lightning_address", None, method_config)
+        check_set_node_conf("lightning_address_comment", None, method_config)
+
     elif method_name == "clightning":
         method_config["name"] = "clightning"
         check_set_node_conf("clightning_rpc_file", None, method_config)

--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,15 @@ lnd_macaroon = "invoice.macaroon"
 [clightning]
 clightning_rpc_file = "/home/user/.lightning/bitcoin/lightning-rpc"
 
+## LNDHUB :: Use BlueWallet (LNDHub) backend for Lightning Network payments
+# With default backend_url will use custodial Blue Wallet backend.
+# To get username / password, look at Wallet Export / Backup in Blue Wallet,
+# it will have URL in format lndhub://bw_login:bw_password@https://lndhub.io
+[lndhub]
+bw_login = ""
+bw_password = ""
+#backend_url = "https://lndhub.herokuapp.com"
+
 [satsale]
 #### Connect To Remote Node ####
 # Either SSH or TOR should be used to 

--- a/node/lndhub.py
+++ b/node/lndhub.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import qrcode
+import time
+from typing import Tuple
+
+import config
+
+
+class lndhub:
+    def __init__(self, node_config: dict) -> None:
+        from blue_wallet_client import BlueWalletClient
+
+        self.config = node_config
+        self.is_onchain = False
+
+        for i in range(config.connection_attempts):
+            try:
+                logging.info("Attempting to initialize LNDHub client...")
+                self.lndhub = BlueWalletClient(
+                    bluewallet_login=self.config["bw_login"],
+                    bluewallet_password=self.config["bw_password"],
+                    root_url=self.config["backend_url"])
+                logging.info("Getting LNDHub node info...")
+                logging.info(json.dumps(self.get_info()))
+                logging.info("Sucessfully contacted LNDHub.")
+                break
+
+            except Exception as e:
+                logging.error(e)
+                if i < 5:
+                    time.sleep(2)
+                else:
+                    time.sleep(60)
+                logging.info(
+                    "Attempting again... {}/{}...".format(
+                        i + 1, config.connection_attempts
+                    )
+                )
+        else:
+            raise Exception("Could not connect to LNDHub.")
+
+        logging.info("Ready for payments requests.")
+        return
+
+    def get_info(self) -> dict:
+        return self.lndhub.get_node_info()
+
+    def create_qr(self, uuid: str, address: str, value: float) -> None:
+        qr_str = "{}".format(address.upper())
+        img = qrcode.make(qr_str)
+        img.save("static/qr_codes/{}.png".format(uuid))
+        return
+
+    def create_lndhub_invoice(self, btc_amount: float, memo: str = None,
+                              expiry: int = 3600) -> Tuple[str, str]:
+        sats_amount = int(float(btc_amount) * 10 ** 8)
+        ret = self.lndhub.create_invoice(amt=sats_amount, memo=memo)
+        return ret["payment_request"], ret["r_hash"]
+
+    def get_address(self, btc_amount: float, label: str,
+                    expiry: int) -> Tuple[str, str]:
+        return self.create_lndhub_invoice(btc_amount, label, expiry)
+
+    def pay_invoice(self, invoice: str) -> None:
+        try:
+            self.lndhub.payinvoice(invoice)
+        except Exception as e:
+            logging.error(e.repr())
+
+    def check_payment(self, rhash: str) -> Tuple[float, float]:
+        invoice = self.lndhub.lookup_invoice(rhash)
+
+        if invoice["ispaid"]:
+            conf_paid = (int(invoice["amt"]) + 1) / (10 ** 8)
+            unconf_paid = 0
+        else:
+            conf_paid = 0
+            unconf_paid = 0
+
+        return conf_paid, unconf_paid

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ bip-utils==2.3.0
 setuptools==50.3.2
 lnd-grpc-client==0.3.22
 pyln-client==0.10.1
+blue_wallet_client==0.0.13

--- a/satsale.py
+++ b/satsale.py
@@ -27,6 +27,7 @@ from payments.price_feed import get_btc_value
 from node import bitcoind
 from node import xpub
 from node import lnd
+from node import lndhub
 from node import clightning
 from utils import btc_amount_format
 
@@ -295,7 +296,7 @@ def check_payment_status(uuid):
     # If payment has not expired, then we're going to check for any transactions
     if status["time_left"] > 0:
         node = get_node(invoice["method"])
-        if node.config['name'] == "lnd":
+        if (node.config['name'] == "lnd") or (node.config['name'] == "lndhub"):
             conf_paid, unconf_paid = node.check_payment(invoice["rhash"])
         elif (node.config['name'] == "bitcoind") or (node.config['name'] == "clightning"):
             # Lookup bitcoind / clightning invoice based on label (uuid)
@@ -361,6 +362,11 @@ for method in config.payment_methods:
         if lightning_node.config['lightning_address'] is not None:
             from gateways import lightning_address
             lightning_address.add_ln_address_decorators(app, api, lightning_node)
+        enabled_payment_methods.append("lightning")
+
+    elif method['name'] == "lndhub":
+        lightning_node = lndhub.lndhub(method)
+        logging.info("Connection to lightning node (lndhub) successful.")
         enabled_payment_methods.append("lightning")
 
     elif method['name'] == "clightning":


### PR DESCRIPTION
Resolves #101.

Custom invoice expiry is not supported here. That needs support at LNDHub. See [discussion here](https://github.com/snow884/blue_wallet_client/issues/1).

In theory LNDHub backend also supports onchain deposits, which would then be swapped to LN BTC, but not sure it's needed, also node classes in SatSale are currently either onchain or LN, not both.