### PR TITLE
Cross Origin Resource Sharing (CORS) of API endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python_bitcoinrpc==1.0
 qrcode==7.3
 Flask==1.1.4
+flask_cors==3.0.10
 MarkupSafe==2.0.1
 requests==2.26.0
 gunicorn==20.0.4

--- a/satsale.py
+++ b/satsale.py
@@ -5,6 +5,7 @@ from flask import (
     make_response
 )
 from flask_restx import Resource, Api, fields
+from flask_cors import CORS
 import time
 import os
 import uuid
@@ -33,6 +34,7 @@ from utils import btc_amount_format
 from gateways import woo_webhook
 
 app = Flask(__name__)
+CORS(app)
 
 # Load a SatSale API key or create a new one
 if os.path.exists("SatSale_API_key"):


### PR DESCRIPTION
This PR helps if you have a satsale instance on `Domain A` but want to call the API on `Domain B` (usually with custom website javascript).

You may also need to add [an NGINX rule](https://serverfault.com/questions/162429/how-do-i-add-access-control-allow-origin-in-nginx)


Should this be another config line (maybe hidden even)? Or could also just leave on a separate branch for those who need it.

