### PR TITLE
Remove unnecessary trailing zeros from amounts in BIP21 URIs

### DIFF
--- a/node/bip21.py
+++ b/node/bip21.py
@@ -21,5 +21,14 @@ def encode_bip21_uri(address: str, params: Union[dict, list]) -> str:
     if len(params) > 0:
         if "amount" in params:
             _validate_bip21_amount(params["amount"])
+            # This will remove unnecessary trailing zeros after decimal point
+            # but will not work for amounts below 0.0001 ("0.00001000" would
+            # be converted to "1e-5").
+            flt_amt = float(params["amount"])
+            int_amt = int(flt_amt)
+            if int_amt == flt_amt:
+                params["amount"] = int_amt
+            elif flt_amt >= 0.0001:
+                params["amount"] = flt_amt
         uri += "?" + urlencode(params, quote_via=quote)
     return uri

--- a/test/test_bip21.py
+++ b/test/test_bip21.py
@@ -55,6 +55,39 @@ def test_bip21_encode() -> None:
         ]) ==
         "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?somethingyoudontunderstand=50&somethingelseyoudontget=999"
     )
+    # Test removal of trailing zeros after decimal point for amounts
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "50.00000000"
+        }) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50"
+    )
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "20.30000000"
+        }) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3"
+    )
+    # Test that zeros from the right side of integers aren't removed
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "5000.00000000"
+        }) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=5000"
+    )
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "5000"
+        }) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=5000"
+    )
+    # Test very small amounts
+    assert (
+        encode_bip21_uri("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W", {
+            "amount": "0.00000001"
+        }) ==
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=0.00000001"
+    )
     # Invalid amounts must raise ValueError
     with pytest.raises(ValueError):
         # test dicts


### PR DESCRIPTION
Sometimes makes URI strings shorter, which is especially important when encoding them into QR codes.