### PR TITLE
Towards universal QR codes

### DIFF
--- a/node/invoices.py
+++ b/node/invoices.py
@@ -1,0 +1,39 @@
+import qrcode
+from enum import Enum
+
+from node.bip21 import encode_bip21_uri
+from utils import btc_amount_format
+
+
+class InvoiceType(Enum):
+    BIP21 = 1,
+    BOLT11 = 2
+
+
+def encode_bitcoin_invoice(uuid: str, invoice: dict,
+                           invtype: InvoiceType) -> str:
+
+    if invtype == InvoiceType.BIP21:
+        assert (invoice["address"])
+        assert (invoice["btc_value"])
+        bip21_params = {
+            "amount": btc_amount_format(invoice["btc_value"]),
+            "label": uuid
+        }
+        if "bolt11_invoice" in invoice and invoice["bolt11_invoice"]:
+            bip21_params["lightning"] = invoice["bolt11_invoice"]
+        return encode_bip21_uri(invoice["address"], bip21_params)
+
+    elif invtype == InvoiceType.BOLT11:
+        assert (invoice["bolt11_invoice"])
+        return invoice["bolt11_invoice"]
+
+    else:
+        raise NotImplementedError(
+            "Unsupported Bitcoin invoice type {}".format(invtype))
+
+
+def create_qr(uuid: str, qr_str: str) -> None:
+    img = qrcode.make(qr_str)
+    img.save("static/qr_codes/{}.png".format(uuid))
+    return

--- a/node/lndhub.py
+++ b/node/lndhub.py
@@ -1,18 +1,18 @@
 import json
 import logging
-import qrcode
 import time
 from typing import Tuple
 
 import config
+from node import node
 
 
-class lndhub:
+class lndhub(node.node):
+
     def __init__(self, node_config: dict) -> None:
         from blue_wallet_client import BlueWalletClient
 
-        self.config = node_config
-        self.is_onchain = False
+        super().__init__(node_config, False)
 
         for i in range(config.connection_attempts):
             try:
@@ -46,12 +46,6 @@ class lndhub:
     def get_info(self) -> dict:
         return self.lndhub.get_node_info()
 
-    def create_qr(self, uuid: str, address: str, value: float) -> None:
-        qr_str = "{}".format(address.upper())
-        img = qrcode.make(qr_str)
-        img.save("static/qr_codes/{}.png".format(uuid))
-        return
-
     def create_lndhub_invoice(self, btc_amount: float, memo: str = None,
                               expiry: int = 3600) -> Tuple[str, str]:
         sats_amount = int(float(btc_amount) * 10 ** 8)
@@ -59,8 +53,10 @@ class lndhub:
         return ret["payment_request"], ret["r_hash"]
 
     def get_address(self, btc_amount: float, label: str,
-                    expiry: int) -> Tuple[str, str]:
-        return self.create_lndhub_invoice(btc_amount, label, expiry)
+                    expiry: int) -> Tuple[str, str, str]:
+        address, r_hash = self.create_lndhub_invoice(
+            btc_amount, label, expiry)
+        return None, address, r_hash
 
     def pay_invoice(self, invoice: str) -> None:
         try:

--- a/node/node.py
+++ b/node/node.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+
+class node(ABC):
+
+    def __init__(self, node_config: dict, is_onchain: bool) -> None:
+        self.config = node_config
+        self.is_onchain = is_onchain
+
+    @abstractmethod
+    def get_info(self):
+        pass
+
+    @abstractmethod
+    def get_address(self, amount: float, label: str,
+                    expiry: int) -> Tuple[str, str, str]:
+        pass
+
+    @abstractmethod
+    def check_payment(self, uuid: str) -> Tuple[float, float]:
+        pass

--- a/payments/database.py
+++ b/payments/database.py
@@ -71,7 +71,26 @@ def migrate_database(name: str = DEFAULT_DATABASE) -> None:
             conn.execute("ALTER TABLE payments RENAME fiat_currency TO base_currency")
         _set_database_schema_version(4, name)
 
-    #if schema_version < 5:
+    if schema_version < 5:
+        _log_migrate_database(4, 5, "Split off bolt11_invoice from address in payments table")
+        rows = load_invoices_from_db("1", name)
+        lightning_uuids = []
+        for row in rows:
+            if row["method"] in ["lightning", "clightning", "lnd"]:
+                lightning_uuids.append(row["uuid"])
+        with sqlite3.connect(name) as conn:
+            conn.execute("ALTER TABLE payments ADD bolt11_invoice TEXT")
+            # Could use batch UPDATE here maybe.
+            # Assume number of rows will be small enough for this to be
+            # good enough.
+            for uuid in lightning_uuids:
+                conn.execute(
+                    "UPDATE payments "
+                    "SET bolt11_invoice = address, address = NULL "
+                    "WHERE uuid = '{}'".format(uuid))
+        _set_database_schema_version(5, name)
+
+    #if schema_version < 6:
     #   do next migration
 
     new_version = _get_database_schema_version(name)
@@ -87,7 +106,10 @@ def write_to_database(invoice: dict, name: str = DEFAULT_DATABASE) -> None:
     with sqlite3.connect(name) as conn:
         cur = conn.cursor()
         cur.execute(
-            "INSERT INTO payments (uuid,base_currency,base_value,btc_value,method,address,time,webhook,rhash) VALUES (?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO payments (uuid, base_currency, base_value, "
+            "btc_value, method, address, time, webhook, rhash, "
+            "bolt11_invoice) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?)",
             (
                 invoice["uuid"],
                 invoice["base_currency"],
@@ -98,6 +120,7 @@ def write_to_database(invoice: dict, name: str = DEFAULT_DATABASE) -> None:
                 invoice["time"],
                 invoice["webhook"],
                 invoice["rhash"],
+                invoice["bolt11_invoice"]
             ),
         )
     return

--- a/satsale.py
+++ b/satsale.py
@@ -29,6 +29,7 @@ from node import xpub
 from node import lnd
 from node import lndhub
 from node import clightning
+from node.invoices import create_qr, encode_bitcoin_invoice, InvoiceType
 from utils import btc_amount_format
 
 from gateways import woo_webhook
@@ -102,7 +103,9 @@ invoice_model = api.model(
         "time": fields.Float(),
         "webhook": fields.String(),
         "rhash": fields.String(),
+        "bolt11_invoice": fields.String(),
         "time_left": fields.Float(),
+        "onchain_dust_limit": fields.Float()
     },
 )
 status_model = api.model(
@@ -181,18 +184,27 @@ class create_payment(Resource):
 
         # Get an address / invoice, and create a QR code
         try:
-            invoice["address"], invoice["rhash"] = node.get_address(
-                invoice["btc_value"], invoice["uuid"], config.payment_timeout
-            )
+            invoice["address"], invoice["bolt11_invoice"], invoice["rhash"] = \
+                node.get_address(
+                    invoice["btc_value"], invoice["uuid"],
+                    config.payment_timeout
+                )
         except Exception as e:
             logging.error("Failed to fetch address: {}".format(e))
             return {"message": "Error fetching address. Check config.."}, 522
 
-        if not invoice["address"]:
+        if not invoice["address"] and not invoice["bolt11_invoice"]:
             logging.error("Failed to fetch address")
             return {"message": "Error fetching address. Check config.."}, 522
 
-        node.create_qr(invoice["uuid"], invoice["address"], invoice["btc_value"])
+        if invoice["method"] == "lightning":
+            invoice_type = InvoiceType.BOLT11
+        else:
+            invoice_type = InvoiceType.BIP21
+
+        btc_invoice_str = encode_bitcoin_invoice(
+            invoice["uuid"], invoice, invoice_type)
+        create_qr(invoice["uuid"], btc_invoice_str)
 
         # Save invoice to database
         database.write_to_database(invoice)
@@ -356,7 +368,7 @@ enabled_payment_methods = []
 for method in config.payment_methods:
     #print(method)
     if method['name'] == "bitcoind":
-        bitcoin_node = bitcoind.btcd(method)
+        bitcoin_node = bitcoind.bitcoind(method)
         logging.info("Connection to bitcoin node successful.")
         enabled_payment_methods.append("onchain")
 

--- a/scripts/generate_payment_report.py
+++ b/scripts/generate_payment_report.py
@@ -40,7 +40,7 @@ def main():
     for method in config.payment_methods:
         print("Connecting to {} node...".format(method["name"]))
         if method["name"] == "bitcoind":
-            nodes["bitcoind"] = bitcoind.btcd(method)
+            nodes["bitcoind"] = bitcoind.bitcoind(method)
             onchain = "bitcoind"
         elif method["name"] == "lnd":
             nodes["lnd"] = lnd.lnd(method)
@@ -66,7 +66,7 @@ def main():
         reportwriter = csv.writer(csvfile)
         reportwriter.writerow([
             "Date", "Invoice ID", "Base value", "Base currency", "BTC value",
-            "BTC paid", "Payment method", "Address"
+            "BTC paid", "Payment method", "Address / invoice"
         ])
         num_rows = 0
         for invoice in invoices:
@@ -84,6 +84,10 @@ def main():
                     invoice["uuid"])
 
             if conf_paid > 0:
+                if invoice["method"] == "lightning":
+                    address = invoice["bolt11_invoice"]
+                else:
+                    address = invoice["address"]
                 reportwriter.writerow([
                     datetime.utcfromtimestamp(
                         int(invoice["time"])).strftime("%Y-%m-%d"),
@@ -93,7 +97,7 @@ def main():
                     "%.8f" % float(invoice["btc_value"]),
                     "%.8f" % float(conf_paid),
                     invoice["method"],
-                    invoice["address"]
+                    address
                 ])
                 num_rows = num_rows + 1
 

--- a/static/satsale.js
+++ b/static/satsale.js
@@ -13,7 +13,12 @@ function payment(payment_data) {
             invoice = data.invoice;
             payment_uuid = invoice.uuid;
 
-            $('#address').text(invoice.address).html();
+            if (invoice.payment_method == 'lightning') {
+                $('#address').text(invoice.bolt11_invoice).html();
+            }
+            else {
+                $('#address').text(invoice.address).html();
+            }
             $('#amount').text(invoice.btc_value).html();
             $('#amount_sats').text(Math.round(invoice.btc_value * 10**8)).html();
             $('#timer').text(Math.round(invoice.time_left)).html();

--- a/test/test_bitcoin_invoices.py
+++ b/test/test_bitcoin_invoices.py
@@ -1,0 +1,55 @@
+import os
+import pytest
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from node.invoices import encode_bitcoin_invoice, InvoiceType
+
+
+@pytest.mark.parametrize(
+    "invoice_data",
+    [
+        {
+            "uuid": "Luke-Jr",
+            "invoice": {
+                "address": "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+                "btc_value": 20.3
+            },
+            "invoice_type": InvoiceType.BIP21,
+            "invoice_str": "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr"
+        },
+        {
+            "uuid": "bolt11_example",
+            "invoice": {
+                "bolt11_invoice": "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr"
+            },
+            "invoice_type": InvoiceType.BOLT11,
+            "invoice_str": "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr"
+        },
+        {
+            "uuid": "bolt11_example",
+            "invoice": {
+                "address": "mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP",
+                "btc_value": 0.02,
+                "bolt11_invoice": "lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8"
+            },
+            "invoice_type": InvoiceType.BOLT11,
+            "invoice_str": "lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8"
+        },
+        {
+            "uuid": "bolt11_example",
+            "invoice": {
+                "address": "mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP",
+                "btc_value": 0.02,
+                "bolt11_invoice": "lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8"
+            },
+            "invoice_type": InvoiceType.BIP21,
+            "invoice_str": "bitcoin:mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP?amount=0.02&label=bolt11_example&lightning=lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8"
+        },
+    ]
+    )
+def test_encode_bitcoin_invoice(invoice_data: list) -> None:
+    assert (
+        encode_bitcoin_invoice(
+            invoice_data["uuid"], invoice_data["invoice"],
+            invoice_data["invoice_type"]) == invoice_data["invoice_str"])

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -49,7 +49,8 @@ def test_database_invoices() -> None:
         "webhook": None,
         "onchain_dust_limit": 0.00000546,
         "address": "testaddr",
-        "rhash": "test"
+        "rhash": None,
+        "bolt11_invoice": None
     }, DB_NAME)
     invoices = load_invoices_from_db("1", DB_NAME)
     invoice0 = load_invoice_from_db(invoice_uuid, DB_NAME)
@@ -63,6 +64,8 @@ def test_database_invoices() -> None:
     assert (invoice0["btc_value"] > 0)
     assert (invoices[0]["address"] == "testaddr")
     assert (invoice0["address"] == "testaddr")
-    assert (invoices[0]["rhash"] == "test")
-    assert (invoice0["rhash"] == "test")
+    assert (invoices[0]["rhash"] is None)
+    assert (invoice0["rhash"] is None)
+    assert (invoices[0]["bolt11_invoice"] is None)
+    assert (invoice0["bolt11_invoice"] is None)
     _drop_test_db()


### PR DESCRIPTION
Big step towards #53. Not a fan of such big changes in a single PR, but these were all kinda related.

Brief summary:

* Move Bitcoin invoice / QR code generation code out of individual nodes + add tests;
* Base class for all node classes (wasn't quite requirement, but seemed nice, now you have clear abstract class that shows minimum required to be implemented for new "node" backends);
* Split off `bolt11_invoice` from onchain `address` in `payments` table (db) [most important thing, this was what I just wanted to do when started doing this];
* More type hints.

Tested on my development laptop with onchain signet, as well as with [donate.kristapsk.lv](https://donate.kristapsk.lv/) (I will be reckless, this code is already running there). But more testing would be great, as there are a lots of LOCs changed.

Basically all the backend functionality needed for unified QR codes are IMHO there, rest remaining is changes in UI/UX and `satsale.py` part. Tried to only change backend things and keep everything the same from UX perspective for now.

For frontend part I actually think some switchable theme thing needs to be implemented, different people / use cases may want different frontends.

P.S. Why don't we have normal primary keys in db tables, etc, but maybe not so important and with current migration scheme it will be PITA.