### PR TITLE
Add optional message (purpose) field for payments

### DIFF
--- a/node/invoices.py
+++ b/node/invoices.py
@@ -20,6 +20,8 @@ def encode_bitcoin_invoice(uuid: str, invoice: dict,
             "amount": btc_amount_format(invoice["btc_value"]),
             "label": uuid
         }
+        if "message" in invoice:
+            bip21_params["message"] = invoice["message"]
         if "bolt11_invoice" in invoice and invoice["bolt11_invoice"]:
             bip21_params["lightning"] = invoice["bolt11_invoice"]
         return encode_bip21_uri(invoice["address"], bip21_params)

--- a/payments/database.py
+++ b/payments/database.py
@@ -89,7 +89,7 @@ def migrate_database(name: str = DEFAULT_DATABASE) -> None:
                     "SET bolt11_invoice = address, address = NULL "
                     "WHERE uuid = '{}'".format(uuid))
         _set_database_schema_version(5, name)
-        
+
     if schema_version < 6:
         _log_migrate_database(4, 5, "Add message column to payments table")
         with sqlite3.connect(name) as conn:

--- a/satsale.py
+++ b/satsale.py
@@ -105,7 +105,8 @@ invoice_model = api.model(
         "rhash": fields.String(),
         "bolt11_invoice": fields.String(),
         "time_left": fields.Float(),
-        "onchain_dust_limit": fields.Float()
+        "onchain_dust_limit": fields.Float(),
+        "message": fields.String()
     },
 )
 status_model = api.model(
@@ -122,7 +123,8 @@ status_model = api.model(
 @api.doc(
     params={
         "amount": "An amount.",
-        "currency": "(Opional) Currency units of the amount (defaults to `config.base_currency`).",
+        "currency": "(Optional) Currency units of the amount (defaults to `config.base_currency`).",
+        "message": "(Optional) Message to send among payment (purpose).",
         "method": "(Optional) Specify a payment method: `bitcoind` for onchain, `lnd` for lightning).",
         "w_url": "(Optional) Specify a webhook url to call after successful payment. Currently only supports WooCommerce plugin.",
     }
@@ -148,6 +150,7 @@ class create_payment(Resource):
             webhook = None
         else:
             logging.info("Webhook payment: {}".format(webhook))
+        payment_message = request.args.get("message")
 
         # Create the payment using one of the connected nodes as a base
         # ready to recieve the invoice.
@@ -193,6 +196,7 @@ class create_payment(Resource):
             "webhook": webhook,
             "onchain_dust_limit": config.onchain_dust_limit,
             "ln_upper_limit": config.ln_upper_limit,
+            "message": payment_message,
         }
 
         # Get an address / invoice, and create a QR code

--- a/satsale.py
+++ b/satsale.py
@@ -151,6 +151,8 @@ class create_payment(Resource):
         else:
             logging.info("Webhook payment: {}".format(webhook))
         payment_message = request.args.get("message")
+        if payment_message is not None and len(payment_message) > 35:
+            payment_message = payment_message[:35]
 
         # Create the payment using one of the connected nodes as a base
         # ready to recieve the invoice.

--- a/scripts/generate_payment_report.py
+++ b/scripts/generate_payment_report.py
@@ -66,7 +66,7 @@ def main():
         reportwriter = csv.writer(csvfile)
         reportwriter.writerow([
             "Date", "Invoice ID", "Base value", "Base currency", "BTC value",
-            "BTC paid", "Payment method", "Address / invoice"
+            "BTC paid", "Payment method", "Address / invoice", "Message"
         ])
         num_rows = 0
         for invoice in invoices:
@@ -97,7 +97,8 @@ def main():
                     "%.8f" % float(invoice["btc_value"]),
                     "%.8f" % float(conf_paid),
                     invoice["method"],
-                    address
+                    address,
+                    invoice["message"]
                 ])
                 num_rows = num_rows + 1
 

--- a/static/satsale.js
+++ b/static/satsale.js
@@ -2,7 +2,7 @@
 function payment(payment_data) {
     $('document').ready(function(){
         var payment_uuid;
-        var invoiceData = {amount: payment_data.amount, currency: payment_data.currency, method: payment_data.method};
+        var invoiceData = {amount: payment_data.amount, currency: payment_data.currency, method: payment_data.method, message: payment_data.message};
 
         // If a webhook URL is provided (woocommerce)
         if (payment_data.w_url) {

--- a/templates/donate.html
+++ b/templates/donate.html
@@ -55,6 +55,9 @@
                     </select>
                     </h2>
                     <br>
+                    <h3 style="margin:0;">Message (optional):<h3>
+                    <textarea class="donate_input" name="message" rows="2"></textarea>
+                    <br>
                     <input class="button button1" style="width:40%" type="submit" value="Donate">
                 </div>
             </form>

--- a/templates/donate.html
+++ b/templates/donate.html
@@ -56,7 +56,7 @@
                     </h2>
                     <br>
                     <h3 style="margin:0;">Message (optional):<h3>
-                    <textarea class="donate_input" name="message" rows="2"></textarea>
+                    <textarea class="donate_input" name="message" rows="2" maxlength="35"></textarea>
                     <br>
                     <input class="button button1" style="width:40%" type="submit" value="Donate">
                 </div>

--- a/test/test_bitcoin_invoices.py
+++ b/test/test_bitcoin_invoices.py
@@ -19,6 +19,16 @@ from node.invoices import encode_bitcoin_invoice, InvoiceType
             "invoice_str": "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr"
         },
         {
+            "uuid": "Luke-Jr",
+            "invoice": {
+                "address": "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+                "btc_value": 50,
+                "message": "Donation for project xyz"
+            },
+            "invoice_type": InvoiceType.BIP21,
+            "invoice_str": "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz"
+        },
+        {
             "uuid": "bolt11_example",
             "invoice": {
                 "bolt11_invoice": "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr"

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -50,7 +50,8 @@ def test_database_invoices() -> None:
         "onchain_dust_limit": 0.00000546,
         "address": "testaddr",
         "rhash": None,
-        "bolt11_invoice": None
+        "bolt11_invoice": None,
+        "message": "Keep BUIDLing!"
     }, DB_NAME)
     invoices = load_invoices_from_db("1", DB_NAME)
     invoice0 = load_invoice_from_db(invoice_uuid, DB_NAME)


### PR DESCRIPTION
This has two use cases.

1) For accepting donations scenario allows to add some custom message to receiver, like "Great work on project XYZ" or "Keep BUIDLing!".

2) For businesses allows to send customer PDF invoices to e-mail were in addition to bank wire payment details link to SatSale instance can be added, with invoice number as message (for example, `/pay?amount=100&currency=EUR&message=INV-000001`), where customer can pay with Bitcoin. Like landlords sending monthly invoices for rent payments or small webshops that want to process every order manually, not have automatic SatSale WooCommerce integration.

Currently information is stored in database `payments` field and can be retrieved with `scripts/generate_payment_report.py`. I think two potential improvements can be made here in future, to make it more practical.

1) Introduce some simple web admin panel / dashboard, where user can browse database contents. Likely some simple hardcoded login / pass in `config.toml` would be enough for SatSale, no need for fancy user / permission management IMHO.

2) E-mail notifications could be sent on payment confirmation.