### PR TITLE
Add back copyable LN invoice string at checkout page

### DIFF
--- a/static/satsale.js
+++ b/static/satsale.js
@@ -13,7 +13,7 @@ function payment(payment_data) {
             invoice = data.invoice;
             payment_uuid = invoice.uuid;
 
-            if (invoice.payment_method == 'lightning') {
+            if (invoice.method == 'lightning') {
                 $('#address').text(invoice.bolt11_invoice).html();
             }
             else {


### PR DESCRIPTION
It was broken by #121, only QR code was shown for LN.