### PR TITLE
Bump bip_utils to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask_restx==0.5.1
 Werkzeug==0.16.1
 PySocks==1.7.1
 toml==0.10.2
-bip-utils==2.3.0
+bip-utils==2.7.0
 
 # For lightning (optional)
 setuptools==50.3.2


### PR DESCRIPTION
While testing some stuff, noticed totally random failures with "`ValueError: unsupported hash type ripemd160`" errors in CI. My hope is that "Always use Cryptodome for _RIPEMD160_" in changelog of 2.4.0 might solve that.