### PR TITLE
Test bitcoind payment flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: bitcoind ${{ matrix.bitcoind-version}}, python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        bitcoind-version: ["24.0.1"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -20,6 +23,18 @@ jobs:
           sudo apt install python3-pip
           pip3 install flake8
           ./test/lint/lint-python.sh
+      - name: Cache bitcoind
+        uses: actions/cache@v3
+        env:
+          cache-name: bitcoind
+          BITCOIND_VERSION: ${{ matrix.bitcoind-version }}
+        with:
+          path: ~/bitcoin/*/bin/bitcoin*
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.BITCOIND_VERSION }}-${{ hashFiles('test/install_bitcoind.sh') }}
+      - name: Install bitcoind
+        env:
+          BITCOIND_VERSION: ${{ matrix.bitcoind-version }}
+        run: ./test/install_bitcoind.sh
       - name: Install SatSale
         run: pip3 install -r requirements.txt
       - name: Run tests

--- a/node/bip21.py
+++ b/node/bip21.py
@@ -2,8 +2,15 @@
 # bitcoin:<address>[?amount=<amount>][?label=<label>][?message=<message>]
 
 from typing import Union
-from urllib.parse import quote, urlencode
+from urllib.parse import parse_qs, quote, unquote_plus, urlencode, urlparse
 import re
+
+from utils import btc_amount_format
+
+
+def _is_bip21_uri(uri: str) -> bool:
+    parsed = urlparse(uri)
+    return parsed.scheme.lower() == "bitcoin" and parsed.path != ""
 
 
 def _is_bip21_amount_str(amount: str) -> bool:
@@ -14,6 +21,25 @@ def _is_bip21_amount_str(amount: str) -> bool:
 def _validate_bip21_amount(amount: Union[float, int, str]) -> None:
     if not _is_bip21_amount_str(str(amount)):
         raise ValueError("Invalid BTC amount " + str(amount))
+
+
+def decode_bip21_uri(uri: str) -> dict:
+    if not _is_bip21_uri(uri):
+        raise ValueError("not a valid BIP21 URI: " + uri)
+    result = {}
+    parsed = urlparse(uri)
+    result["address"] = parsed.path
+    params = parse_qs(parsed.query)
+    for key in params:
+        if key.startswith("req-"):
+            raise ValueError("Unknown required parameter " + key +
+                             " in BIP21 URI.")
+        if key == "amount":
+            _validate_bip21_amount(params[key][0])
+            result["amount"] = btc_amount_format(params["amount"][0])
+        else:
+            result[key] = unquote_plus(params[key][0])
+    return result
 
 
 def encode_bip21_uri(address: str, params: Union[dict, list]) -> str:

--- a/test/bitcoin.conf
+++ b/test/bitcoin.conf
@@ -1,0 +1,4 @@
+[regtest]
+rpcuser=SatSale
+rpcpassword=12345678
+fallbackfee=0.0002

--- a/test/config.toml
+++ b/test/config.toml
@@ -3,3 +3,4 @@
 payment_methods = []
 
 [satsale]
+connection_attempts = 15

--- a/test/install_bitcoind.sh
+++ b/test/install_bitcoind.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ev
+
+if [[ -z "$BITCOIND_VERSION" ]]; then
+    echo "BITCOIND_VERSION must be set"
+    exit 1
+fi
+
+if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind; then
+    echo "found cached bitcoind"
+    sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+else
+    mkdir -p ~/bitcoin && \
+    pushd ~/bitcoin && \
+    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
+    tar xvfz bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
+    sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
+    sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \
+    popd
+fi

--- a/test/test_bitcoind.py
+++ b/test/test_bitcoind.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from node.bitcoind import bitcoind
+from node.invoices import encode_bitcoin_invoice, InvoiceType
+
+
+TEST_RPC_WALLET_NAME = "SatSale-test"
+bitcoin_datadir = tempfile.TemporaryDirectory().name
+os.mkdir(bitcoin_datadir)
+bitcoin_args = [
+    "-regtest",
+    "-conf=" + os.path.join(os.path.dirname(__file__), "bitcoin.conf"),
+    "-datadir=" + bitcoin_datadir
+]
+
+
+def _start_bitcoind() -> None:
+    subprocess.call(["bitcoind"] + bitcoin_args + ["-daemon"])
+    time.sleep(1)
+    subprocess.run(["bitcoin-cli"] + bitcoin_args + [
+        "createwallet", TEST_RPC_WALLET_NAME])
+
+
+def _stop_bitcoind() -> None:
+    subprocess.run(["bitcoin-cli"] + bitcoin_args + ["stop"])
+
+
+def test_bitcoind_payment_flow() -> None:
+    _start_bitcoind()
+    # We don't specify these in test/config.toml, as this is unnecessary
+    # for other tests.
+    node_config = {
+        "host": "localhost",
+        "rpcport": 18443,
+        "rpc_cookie_file": None,
+        "username": "SatSale",
+        "password": "12345678",
+        "tor_bitcoinrpc_host": None,
+        "wallet": TEST_RPC_WALLET_NAME
+    }
+    node = bitcoind(node_config)
+    coinbase_address, _, _ = node.get_address(1, "", 0)
+    node.mine_coins(121, coinbase_address)
+    invoice_uuid = "test-invoice"
+    invoice_address, _, _ = node.get_address(1, invoice_uuid, 0)
+    invoice_amount = 1.23456789
+    # no payment made, should be no incoming UTXOs
+    conf_paid, unconf_paid = node.check_payment(invoice_uuid)
+    assert (conf_paid == 0)
+    assert (unconf_paid == 0)
+    # generate BIP21 invoice and pay
+    invoice_str = encode_bitcoin_invoice(invoice_uuid, {
+        "address": invoice_address,
+        "btc_value": invoice_amount
+    }, InvoiceType.BIP21)
+    node.pay_invoice(invoice_str)
+    # payment made, should have 0 confirmed, invoice amount unconfirmed
+    conf_paid, unconf_paid = node.check_payment(invoice_uuid)
+    assert (conf_paid == 0)
+    assert (unconf_paid == invoice_amount)
+    # mine some more blocks
+    node.mine_coins(50, coinbase_address)
+    # more blocks mined, should have all invoice amount confirmed
+    conf_paid, unconf_paid = node.check_payment(invoice_uuid)
+    assert (conf_paid == invoice_amount)
+    assert (unconf_paid == 0)
+    _stop_bitcoind()


### PR DESCRIPTION
This is somewhat inspired by #5, but simpler. Some code taken from JoinMarket (most of it written by me). Tests SatSale payment flow for bitcoind backend. Similar regtest tests can (and in future should) be added for CLN and LND too, but that's more complicated, as multiple Lightning nodes and channel between them needs to be created, there we likely should look at that [lnbpb-testkit](https://github.com/Kixunil/lnpbp-testkit) by @Kixunil. This also does not test frontend part as #5 does, just `bitcoind` class payment flow functions.

There is support to also test on different Bitcoin Core versions in CI, but that was too slow with my tests and often even didn't finish at all. Just using some recent version will be good enough for now IMO. We don't use many different and complicated RPCs, so probablity of them breaking between Core versions isn't so big. 

Tests only basic flow, where user pays all requested amount in a single transactions. Tests for cases of underpay, overpay, payment in multiple transactions could be added later, in a follow-up PR.