### PR TITLE
CI: Bump Bitcoin Core from 25.1 to 26.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        bitcoind-version: ["25.1"]
+        bitcoind-version: ["26.1"]
         python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
 


### PR DESCRIPTION
According to https://bitnodes.io/dashboard/ 26.x is the most used version currently (but we could test multiple versions in future).