### PR TITLE
Remove unnecessary +1 from Lightning amount calculations

### DIFF
--- a/node/lnd.py
+++ b/node/lnd.py
@@ -166,8 +166,7 @@ class lnd(node.node):
             unconf_paid = Decimal(0)
         else:
             # Store amount paid and convert to BTC units
-            conf_paid = Decimal(
-                (int(invoice_status["amtPaidSat"]) + 1) / (10 ** 8))
+            conf_paid = Decimal(invoice_status["amtPaidSat"]) / Decimal(10 ** 8)
             unconf_paid = Decimal(0)
 
         return conf_paid, unconf_paid

--- a/node/lndhub.py
+++ b/node/lndhub.py
@@ -75,7 +75,7 @@ class lndhub(node.node):
         invoice = self.lndhub.lookup_invoice(rhash)
 
         if invoice["ispaid"]:
-            conf_paid = Decimal((int(invoice["amt"]) + 1) / (10 ** 8))
+            conf_paid = Decimal(invoice["amt"]) / Decimal(10 ** 8)
             unconf_paid = Decimal(0)
         else:
             conf_paid = Decimal(0)

--- a/test/test_lightning_amounts.py
+++ b/test/test_lightning_amounts.py
@@ -1,0 +1,87 @@
+import json
+import os
+import sys
+from base64 import b64encode
+from decimal import Decimal
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from node import lnd as lnd_module
+from node.lnd import lnd
+from node.lndhub import lndhub
+
+
+class FakeLNDClient:
+    def __init__(self, invoice_response):
+        self.invoice_response = invoice_response
+
+    def lookup_invoice(self, r_hash_str):
+        return self.invoice_response
+
+
+class FakeLNDHubClient:
+    def __init__(self, invoice_response):
+        self.invoice_response = invoice_response
+
+    def lookup_invoice(self, rhash):
+        return self.invoice_response
+
+
+def test_lnd_check_payment_does_not_add_extra_sat(monkeypatch):
+    monkeypatch.setattr(
+        lnd_module,
+        "MessageToJson",
+        lambda msg: json.dumps(msg),
+    )
+
+    lightning_node = lnd.__new__(lnd)
+    lightning_node.lnd = FakeLNDClient({"amtPaidSat": "1000"})
+
+    rhash = b64encode(b"test_hash").decode()
+    conf_paid, unconf_paid = lightning_node.check_payment(rhash)
+
+    assert conf_paid == Decimal("0.00001000")
+    assert unconf_paid == Decimal(0)
+
+
+def test_lnd_check_payment_returns_zero_for_unpaid_invoice(monkeypatch):
+    monkeypatch.setattr(
+        lnd_module,
+        "MessageToJson",
+        lambda msg: json.dumps(msg),
+    )
+
+    lightning_node = lnd.__new__(lnd)
+    lightning_node.lnd = FakeLNDClient({})
+
+    rhash = b64encode(b"test_hash").decode()
+    conf_paid, unconf_paid = lightning_node.check_payment(rhash)
+
+    assert conf_paid == Decimal(0)
+    assert unconf_paid == Decimal(0)
+
+
+def test_lndhub_check_payment_does_not_add_extra_sat():
+    lightning_node = lndhub.__new__(lndhub)
+    lightning_node.lndhub = FakeLNDHubClient({
+        "ispaid": True,
+        "amt": "1000",
+    })
+
+    conf_paid, unconf_paid = lightning_node.check_payment("test_rhash")
+
+    assert conf_paid == Decimal("0.00001000")
+    assert unconf_paid == Decimal(0)
+
+
+def test_lndhub_check_payment_returns_zero_for_unpaid_invoice():
+    lightning_node = lndhub.__new__(lndhub)
+    lightning_node.lndhub = FakeLNDHubClient({
+        "ispaid": False,
+        "amt": "1000",
+    })
+
+    conf_paid, unconf_paid = lightning_node.check_payment("test_rhash")
+
+    assert conf_paid == Decimal(0)
+    assert unconf_paid == Decimal(0)


### PR DESCRIPTION
Fixes #174.

This removes the extra `+1` from Lightning payment amount conversions in the LND and LNDHub backends.

The previous logic added one satoshi before converting paid invoice amounts to BTC. Since these values are handled with `Decimal`, the extra satoshi is no longer needed and can make reported paid amounts slightly higher than the actual amount.

Changes:
- Remove `+1` from `node/lnd.py`
- Remove `+1` from `node/lndhub.py`
- Convert sats to BTC using Decimal division instead of float division