### PR TITLE
ci: remove python 3.8, keep only 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         bitcoind-version: ["26.1"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Python 3.9 is already EOL.