### PR TITLE
ui: hide qr code and payment details after expiry (quick and dirty way)

### DIFF
--- a/static/satsale.js
+++ b/static/satsale.js
@@ -51,6 +51,11 @@ function check_payment(payment_uuid, checkinterval, payment_data) {
         payment_status = checkpayment_data.status;
         console.log(payment_status);
         if (payment_status.expired == 1) {
+            $('#qrClick').hide();
+            $('#address').hide();
+            $('#amount').hide();
+            $('#amount_sats').hide();
+            $('#timer').hide();
             $('#status').text("Payment expired.").html();
             document.getElementById('timerContainer').style.visibility = "hidden";
             clearInterval(checkinterval);


### PR DESCRIPTION
To reduce risk that user might send onchain payment after expiry.

Doesn't look perfect, but IMHO good enough for the start.

<img width="451" height="299" alt="image" src="https://github.com/user-attachments/assets/4e48b0f8-2a97-431f-a3da-8c5588874549" />
